### PR TITLE
Merge Tweaks #1 (#64) to alpha branch

### DIFF
--- a/app/javascript/mastodon/features/compose/components/poll_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/poll_form.jsx
@@ -82,7 +82,7 @@ const Option = ({ multipleChoice, index, title, autoFocus }) => {
 
       <AutosuggestInput
         placeholder={intl.formatMessage(messages.option_placeholder, { number: index + 1 })}
-        maxLength={50}
+        maxLength={100}
         value={title}
         lang={lang}
         spellCheck
@@ -147,6 +147,7 @@ export const PollForm = () => {
           { value: 86400, label: intl.formatMessage(messages.days, { number: 1 })},
           { value: 259200, label: intl.formatMessage(messages.days, { number: 3 })},
           { value: 604800, label: intl.formatMessage(messages.days, { number: 7 })},
+          { value: 1209600, label: intl.formatMessage(messages.days, { number: 14 })},
         ]} value={expiresIn} onChange={handleDurationChange} />
 
         <div className='compose-form__poll__footer__sep' />

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -160,7 +160,7 @@ class NavigationPanel extends Component {
           )}
 
           {(signedIn || timelinePreview) && (
-            <ColumnLink transparent to='/public/local' isActive={this.isFirehoseActive} icon='globe' iconComponent={PublicIcon} text={intl.formatMessage(messages.firehose)} />
+            <ColumnLink transparent to='/public' isActive={this.isFirehoseActive} icon='globe' iconComponent={PublicIcon} text={intl.formatMessage(messages.firehose)} />
           )}
 
           {!signedIn && (

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -67,7 +67,7 @@ class Account < ApplicationRecord
   BACKGROUND_REFRESH_INTERVAL = 1.week.freeze
   REFRESH_DEADLINE = 6.hours
   STALE_THRESHOLD = 1.day
-  DEFAULT_FIELDS_SIZE = 4
+  DEFAULT_FIELDS_SIZE = 6
   INSTANCE_ACTOR_ID = -99
 
   USERNAME_RE   = /[a-z0-9_]+([.-]+[a-z0-9_]+)*/i

--- a/app/validators/poll_validator.rb
+++ b/app/validators/poll_validator.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class PollValidator < ActiveModel::Validator
-  MAX_OPTIONS      = 4
-  MAX_OPTION_CHARS = 50
+  MAX_OPTIONS      = 10
+  MAX_OPTION_CHARS = 100
   MAX_EXPIRATION   = 1.month.freeze
   MIN_EXPIRATION   = 5.minutes.freeze
 

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  MAX_CHARS = 500
+  MAX_CHARS = 4242
   URL_PLACEHOLDER_CHARS = 23
   URL_PLACEHOLDER = 'x' * 23
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,7 @@ defaults: &defaults
   closed_registrations_message: ''
   timeline_preview: true
   show_staff_badge: true
+  auto_play_gif: true
   preview_sensitive_media: false
   noindex: false
   theme: 'system'


### PR DESCRIPTION
* Update account.rb

Increase profile metadata fields to 6

* Update settings.yml

Autoplay gifs for logged-out visitors

* Update status_length_validator.rb

Testing `ENV.fetch('MAX_POST_CHARS', 500).to_i` to set via env

* Update navigation_panel.jsx

Change the "Live feeds" page to show "All" instead of "This server" by default

* Update poll_validator.rb

Increase poll options to 10 & max characters to 100

* Update poll_form.jsx

Add 14 days duration option to poll forms

* Update poll_form.jsx

* Delete app/javascript/mastodon/features/compose/components/poll_form.jsx

* Update poll_form.jsx

Add 14 days duration option to poll forms and character limit to 100

* Revert status_length_validator.rb and corrected